### PR TITLE
When using string x-values, allow minMaxValues to work.

### DIFF
--- a/jquery.flot.orderBars.js
+++ b/jquery.flot.orderBars.js
@@ -82,6 +82,10 @@
                 minMaxValues[0] = series[i].data[0][AxeIdx];
                 minMaxValues[1] = series[i].data[series[i].data.length - 1][AxeIdx];
             }
+            if(typeof minMaxValues[0] == 'string'){
+                minMaxValues[0] = 0;
+                minMaxValues[1] = series[0].data.length - 1;
+            }
             return minMaxValues;
         }
 


### PR DESCRIPTION
if you use the category plugin, this plugin breaks as the min and max values will be strings. If the min and max are strings, use 0 and data length.
