### PR TITLE
Fix for bad barWidth measurement

### DIFF
--- a/jquery.flot.orderBars.js
+++ b/jquery.flot.orderBars.js
@@ -187,7 +187,7 @@
     	}
         
         function  calculBorderAndBarWidth(serie){
-            borderWidth = serie.bars.lineWidth ? serie.bars.lineWidth  : 2;
+            borderWidth = typeof serie.bars.lineWidth === "number" ? serie.bars.lineWidth  : 2;
             borderWidthInXabsWidth = borderWidth * pixelInXWidthEquivalent;
         }
         


### PR DESCRIPTION
Fix for a bug that mis-measures barWidth when series.bars.lineWidth is set to 0
