### PR TITLE
Improving orderBars to also shift single bars by half their width

### DIFF
--- a/jquery.flot.orderBars.js
+++ b/jquery.flot.orderBars.js
@@ -58,6 +58,13 @@
 
                     shiftedPoints = shiftPoints(datapoints,serie,decallage);
                     datapoints.points = shiftedPoints;
+               } else if (nbOfBarsToOrder == 1){
+                   // To be consistent with the barshift at other uneven numbers of bars, where
+                   // the center bar is centered around the point, we also need to shift a single bar
+                   // left by half its width
+                   var centerBarShift = -1*calculCenterBarShift();
+                   shiftedPoints = shiftPoints(datapoints,serie,centerBarShift);
+                   datapoints.points = shiftedPoints;
                }
            }
            return shiftedPoints;
@@ -107,71 +114,71 @@
         }
 
         function sortByOrder(series){
-        	var n = series.length;
-        	do {
-	        	for (var i=0; i < n - 1; i++) {
-        			if (series[i].bars.order > series[i + 1].bars.order) {
-        				var tmp = series[i];
-        				series[i] = series[i + 1];
-        				series[i + 1] = tmp;
-        			}
-        			else if (series[i].bars.order == series[i + 1].bars.order) {
-        				
-        				//check if any of the series has set sameSeriesArrayIndex
-        				var sameSeriesIndex;
-        				if (series[i].sameSeriesArrayIndex) {
-        					if(series[i + 1].sameSeriesArrayIndex !== undefined) {
-        						sameSeriesIndex = series[i].sameSeriesArrayIndex;
-        						series[i + 1].sameSeriesArrayIndex = sameSeriesIndex;
-        						sameSeries[sameSeriesIndex].push(series[i + 1]);        						
-        						sameSeries[sameSeriesIndex].sort(sortByWidth);
-        						
-        						series[i] = sameSeries[sameSeriesIndex][0];
-        						removeElement(series, i + 1);
-        					}
-        				}
-        				
-        				else if (series[i + 1].sameSeriesArrayIndex) {
-        					if(series[i].sameSeriesArrayIndex !== undefined) {
-        						sameSeriesIndex = series[i + 1].sameSeriesArrayIndex;
-        						series[i].sameSeriesArrayIndex = sameSeriesIndex;
-        						sameSeries[sameSeriesIndex].push(series[i]);        						
-        						sameSeries[sameSeriesIndex].sort(sortByWidth);
-        						
-        						series[i] = sameSeries[sameSeriesIndex][0];
-        						removeElement(series, i + 1);
-        						
-        					}
-        				}
-        				
-        				else {
-        					sameSeriesIndex = sameSeries.length;
-        					sameSeries[sameSeriesIndex] = new Array();
-        					series[i].sameSeriesArrayIndex = sameSeriesIndex;
-        					series[i + 1].sameSeriesArrayIndex = sameSeriesIndex;
-    						sameSeries[sameSeriesIndex].push(series[i]);      
-    						sameSeries[sameSeriesIndex].push(series[i + 1]);  
-    						sameSeries[sameSeriesIndex].sort(sortByWidth);
-    						
-    						series[i] = sameSeries[sameSeriesIndex][0];
-    						removeElement(series, i + 1);
-        				}
-						i--;
-						n--;
+            var n = series.length;
+            do {
+                for (var i=0; i < n - 1; i++) {
+                    if (series[i].bars.order > series[i + 1].bars.order) {
+                        var tmp = series[i];
+                        series[i] = series[i + 1];
+                        series[i + 1] = tmp;
+                    }
+                    else if (series[i].bars.order == series[i + 1].bars.order) {
+                        
+                        //check if any of the series has set sameSeriesArrayIndex
+                        var sameSeriesIndex;
+                        if (series[i].sameSeriesArrayIndex) {
+                            if(series[i + 1].sameSeriesArrayIndex !== undefined) {
+                                sameSeriesIndex = series[i].sameSeriesArrayIndex;
+                                series[i + 1].sameSeriesArrayIndex = sameSeriesIndex;
+                                sameSeries[sameSeriesIndex].push(series[i + 1]);                                
+                                sameSeries[sameSeriesIndex].sort(sortByWidth);
+                                
+                                series[i] = sameSeries[sameSeriesIndex][0];
+                                removeElement(series, i + 1);
+                            }
+                        }
+                        
+                        else if (series[i + 1].sameSeriesArrayIndex) {
+                            if(series[i].sameSeriesArrayIndex !== undefined) {
+                                sameSeriesIndex = series[i + 1].sameSeriesArrayIndex;
+                                series[i].sameSeriesArrayIndex = sameSeriesIndex;
+                                sameSeries[sameSeriesIndex].push(series[i]);                                
+                                sameSeries[sameSeriesIndex].sort(sortByWidth);
+                                
+                                series[i] = sameSeries[sameSeriesIndex][0];
+                                removeElement(series, i + 1);
+                                
+                            }
+                        }
+                        
+                        else {
+                            sameSeriesIndex = sameSeries.length;
+                            sameSeries[sameSeriesIndex] = new Array();
+                            series[i].sameSeriesArrayIndex = sameSeriesIndex;
+                            series[i + 1].sameSeriesArrayIndex = sameSeriesIndex;
+                            sameSeries[sameSeriesIndex].push(series[i]);      
+                            sameSeries[sameSeriesIndex].push(series[i + 1]);  
+                            sameSeries[sameSeriesIndex].sort(sortByWidth);
+                            
+                            series[i] = sameSeries[sameSeriesIndex][0];
+                            removeElement(series, i + 1);
+                        }
+                        i--;
+                        n--;
 
-        				
-        				//leave the wider serie and the other one move to 
-        			}
-        		}
-	        	n = n-1;
-	        }
-        	while (n>1);
-        	for (var i=0; i < series.length; i++) {
-        		if (series[i].sameSeriesArrayIndex) {
-        			seriesPos[series[i].sameSeriesArrayIndex] = i;
-        		}
-        	}
-        	return series;
+                        
+                        //leave the wider serie and the other one move to 
+                    }
+                }
+                n = n-1;
+            }
+            while (n>1);
+            for (var i=0; i < series.length; i++) {
+                if (series[i].sameSeriesArrayIndex) {
+                    seriesPos[series[i].sameSeriesArrayIndex] = i;
+                }
+            }
+            return series;
         }
         
         function sortByWidth(serie1,serie2){
@@ -180,11 +187,11 @@
             return ((x < y) ? -1 : ((x > y) ? 1 : 0));
         }
         function removeElement(arr, from, to) {
-		    var rest = arr.slice((to || from) + 1 || arr.length);
-		    arr.length = from < 0 ? arr.length + from : from;
-		    arr.push.apply(arr, rest);
-		    return arr;
-    	}
+            var rest = arr.slice((to || from) + 1 || arr.length);
+            arr.length = from < 0 ? arr.length + from : from;
+            arr.push.apply(arr, rest);
+            return arr;
+        }
         
         function  calculBorderAndBarWidth(serie){
             borderWidth = serie.bars.lineWidth ? serie.bars.lineWidth  : 2;
@@ -198,19 +205,19 @@
         }
 
         function findPosition(serie){
-        	var ss = sameSeries;
-        	var pos = 0;
-        	if (serie.sameSeriesArrayIndex) {
-        		pos = seriesPos[serie.sameSeriesArrayIndex];
-        	}
-        	else {
-	            for (var i = 0; i < orderedBarSeries.length; ++i) {
-	                if (serie == orderedBarSeries[i]){
-	                    pos = i;
-	                    break;
-	                }
-	            }
-        	}
+            var ss = sameSeries;
+            var pos = 0;
+            if (serie.sameSeriesArrayIndex) {
+                pos = seriesPos[serie.sameSeriesArrayIndex];
+            }
+            else {
+                for (var i = 0; i < orderedBarSeries.length; ++i) {
+                    if (serie == orderedBarSeries[i]){
+                        pos = i;
+                        break;
+                    }
+                }
+            }
             return pos+1;
         }
 
@@ -218,7 +225,9 @@
             var width = 0;
 
             if(nbOfBarsToOrder%2 != 0)
-                width = (orderedBarSeries[Math.ceil(nbOfBarsToOrder / 2)].bars.barWidth)/2;
+                // Since the array indexing starts at 0, we need to use Math.floor instead of
+                // Math.ceil otherwise we will get an error if there is only one bar
+                width = (orderedBarSeries[Math.floor(nbOfBarsToOrder / 2)].bars.barWidth)/2;
 
             return width;
         }


### PR DESCRIPTION
The behavior of the plugin was inconsistent if only one bar was displayed. In such a case the bar was not shifted. If there was any other uneven number of bars, the center bar was shifted by half its width to be displayed centered around the x value. I added some code to also allow this behavior for single bars.
(Code on lines 61-67 and 228-230)
The remaining changes are a result of me replacing all tabs by spaces to have a consistent usage of spaces for tabs.
